### PR TITLE
arrowParens set to always

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -9,7 +9,7 @@
   "trailingComma": "none",
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
-  "arrowParens": "avoid",
+  "arrowParens": "always",
   "endOfLine": "auto",
   "overrides": [
     {


### PR DESCRIPTION
Following [best practices](https://prettier.io/docs/en/options.html#arrow-function-parentheses):

`At first glance, avoiding parentheses may look like a better choice because of less visual noise. However, when Prettier removes parentheses, it becomes harder to add type annotations, extra arguments or default values as well as making other changes. Consistent use of parentheses provides a better developer experience when editing real codebases, which justifies the default value for the option.`