### PR TITLE
Prettier and VSCode config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,7 +281,8 @@ dmypy.json
 .pyre/
 
 ### VisualStudioCode ###
-.vscode/
+# format on save enabled
+# .vscode/
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
   "tabWidth": 2,
   "useTabs": false,
   "semi": false,
-  "singleQuote": false,
+  "singleQuote": true,
   "quoteProps": "as-needed",
   "jsxSingleQuote": false,
   "trailingComma": "none",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}


### PR DESCRIPTION
Changes `.prettierrc` to always single quote, adds `formatOnSave` property to workspace VSCode settings (`.vscode` dir)